### PR TITLE
Support portID and PVID facts from Nexus neighbors

### DIFF
--- a/lib/facter/openlldp.rb
+++ b/lib/facter/openlldp.rb
@@ -63,7 +63,7 @@ if File.exists?('/usr/sbin/lldptool')
               end
             when 'portID'
               output.split("\n").each do |line|
-                result = $1 if line.match(/Ifname:\s+(.*)/)
+                result = $1 if line.match(/(?:Ifname|Local):\s+(.*)/)
               end
             when 'mngAddr_ipv4'
               output.split("\n").each do |line|
@@ -75,7 +75,7 @@ if File.exists?('/usr/sbin/lldptool')
               end
             when 'PVID'
               output.split("\n").each do |line|
-                result = $1.to_i if line.match(/Info:\s+(.*)/)
+                result = $1.to_i if line.match(/(?:Info|PVID):\s+(.*)/)
               end
             else
               # case default

--- a/spec/fixtures/unit/facter/openlldp/PVID-nexus
+++ b/spec/fixtures/unit/facter/openlldp/PVID-nexus
@@ -1,0 +1,2 @@
+Port VLAN ID TLV
+	PVID: 116

--- a/spec/fixtures/unit/facter/openlldp/portID-nexus
+++ b/spec/fixtures/unit/facter/openlldp/portID-nexus
@@ -1,0 +1,2 @@
+Port ID TLV
+	Local: Eth102/1/32

--- a/spec/unit/facter/openlldp_spec.rb
+++ b/spec/unit/facter/openlldp_spec.rb
@@ -138,4 +138,15 @@ describe 'lldptool is installed' do
       Facter.value(:lldp_neighbor_mtu_em2).should == '9236'
     end
   end
+
+  context 'with Nexus LLDP neighbor' do
+    it 'lldp_neighbor_portid_em2 is Eth102/1/32' do
+      Facter::Util::Resolution.stubs(:exec).with('lldptool get-tlv -n -i em2 -V 2 2>/dev/null').returns(my_fixture_read('portID-nexus'))
+      Facter.value(:lldp_neighbor_portid_em2).should == 'Eth102/1/32'
+    end
+    it 'lldp_neighbor_pvid_em2 is 116' do
+      Facter::Util::Resolution.stubs(:exec).with('lldptool get-tlv -n -i em2 -V 0x0080c201 2>/dev/null').returns(my_fixture_read('PVID-nexus'))
+      Facter.value(:lldp_neighbor_pvid_em2).should == 116
+    end
+  end
 end


### PR DESCRIPTION
LLDP neighbors running Cisco Nexus Operating System (NX-OS) Software return slightly different data for portID and PVID queries.
