### PR TITLE
add path param to all exec statements

### DIFF
--- a/manifests/config/lldp.pp
+++ b/manifests/config/lldp.pp
@@ -68,6 +68,8 @@ define openlldp::config::lldp (
   }
 
   exec { "set-lldp ${interface}" :
+    # /bin/grep & /usr/sbin/lldptool
+    path    => ['/bin', '/usr/sbin'],
     command => "lldptool set-lldp -i ${interface} ${scope} adminStatus=${adminstatus}",
     onlyif  => "lldptool get-lldp -i ${interface} ${scope} adminStatus | grep -qv adminStatus=${adminstatus}",
   }

--- a/manifests/config/tlv.pp
+++ b/manifests/config/tlv.pp
@@ -97,6 +97,11 @@ define openlldp::config::tlv (
     }
   }
 
+  Exec {
+    # /bin/grep & /usr/sbin/lldptool
+    path => ['/bin', '/usr/sbin']
+  }
+
   exec { "set-tlv ${interface} portDesc" :
     command => "lldptool set-tlv -i ${interface} ${scope} -V portDesc -c enableTx=${portDesc}",
     onlyif  => "lldptool get-tlv -i ${interface} ${scope} -V portDesc -c enableTx | grep -qv enableTx=${portDesc}",

--- a/spec/defines/openlldp_config_lldp_spec.rb
+++ b/spec/defines/openlldp_config_lldp_spec.rb
@@ -25,6 +25,7 @@ describe 'openlldp::config::lldp', :type => 'define' do
     let(:params) {{ :adminstatus => 'disabled' }}
 
     it { should contain_exec('set-lldp myETHERNET').with(
+      :path    => ['/bin', '/usr/sbin'],
       :command => 'lldptool set-lldp -i myETHERNET -g nb adminStatus=disabled',
       :onlyif  => 'lldptool get-lldp -i myETHERNET -g nb adminStatus | grep -qv adminStatus=disabled'
     )}
@@ -34,6 +35,7 @@ describe 'openlldp::config::lldp', :type => 'define' do
     let(:params) {{ :adminstatus => 'rx' }}
 
     it { should contain_exec('set-lldp myETHERNET').with(
+      :path    => ['/bin', '/usr/sbin'],
       :command => 'lldptool set-lldp -i myETHERNET -g nb adminStatus=rx',
       :onlyif  => 'lldptool get-lldp -i myETHERNET -g nb adminStatus | grep -qv adminStatus=rx'
     )}
@@ -43,6 +45,7 @@ describe 'openlldp::config::lldp', :type => 'define' do
     let(:params) {{ :adminstatus => 'tx' }}
 
     it { should contain_exec('set-lldp myETHERNET').with(
+      :path    => ['/bin', '/usr/sbin'],
       :command => 'lldptool set-lldp -i myETHERNET -g nb adminStatus=tx',
       :onlyif  => 'lldptool get-lldp -i myETHERNET -g nb adminStatus | grep -qv adminStatus=tx'
     )}
@@ -52,6 +55,7 @@ describe 'openlldp::config::lldp', :type => 'define' do
     let(:params) {{ :adminstatus => 'rxtx' }}
 
     it { should contain_exec('set-lldp myETHERNET').with(
+      :path    => ['/bin', '/usr/sbin'],
       :command => 'lldptool set-lldp -i myETHERNET -g nb adminStatus=rxtx',
       :onlyif  => 'lldptool get-lldp -i myETHERNET -g nb adminStatus | grep -qv adminStatus=rxtx'
     )}
@@ -79,6 +83,7 @@ describe 'openlldp::config::lldp', :type => 'define' do
     end
 
     it { should contain_exec('set-lldp myETHERNET').with(
+      :path    => ['/bin', '/usr/sbin'],
       :command => 'lldptool set-lldp -i myETHERNET -g ncb adminStatus=rxtx',
       :onlyif  => 'lldptool get-lldp -i myETHERNET -g ncb adminStatus | grep -qv adminStatus=rxtx'
     )}
@@ -92,6 +97,7 @@ describe 'openlldp::config::lldp', :type => 'define' do
     end
 
     it { should contain_exec('set-lldp myETHERNET').with(
+      :path    => ['/bin', '/usr/sbin'],
       :command => 'lldptool set-lldp -i myETHERNET -g nntpmrb adminStatus=rxtx',
       :onlyif  => 'lldptool get-lldp -i myETHERNET -g nntpmrb adminStatus | grep -qv adminStatus=rxtx'
     )}

--- a/spec/defines/openlldp_config_tlv_spec.rb
+++ b/spec/defines/openlldp_config_tlv_spec.rb
@@ -36,6 +36,7 @@ describe 'openlldp::config::tlv', :type => 'define' do
   context 'default parameters' do
     tlvlist.each do |tlv|
       it { should contain_exec("set-tlv myETHERNET #{tlv}").with(
+        :path    => ['/bin', '/usr/sbin'],
         :command => "lldptool set-tlv -i myETHERNET -g nb -V #{tlv} -c enableTx=no",
         :onlyif  => "lldptool get-tlv -i myETHERNET -g nb -V #{tlv} -c enableTx | grep -qv enableTx=no"
       )}
@@ -47,6 +48,7 @@ describe 'openlldp::config::tlv', :type => 'define' do
       let(:params) {{ tlv.to_sym => 'yes' }}
 
       it { should contain_exec("set-tlv myETHERNET #{tlv}").with(
+        :path    => ['/bin', '/usr/sbin'],
         :command => "lldptool set-tlv -i myETHERNET -g nb -V #{tlv} -c enableTx=yes",
         :onlyif  => "lldptool get-tlv -i myETHERNET -g nb -V #{tlv} -c enableTx | grep -qv enableTx=yes"
       )}
@@ -61,6 +63,7 @@ describe 'openlldp::config::tlv', :type => 'define' do
     end
 
     it { should contain_exec('set-tlv myETHERNET portDesc').with(
+      :path    => ['/bin', '/usr/sbin'],
       :command => 'lldptool set-tlv -i myETHERNET -g nntpmrb -V portDesc -c enableTx=yes',
       :onlyif  => 'lldptool get-tlv -i myETHERNET -g nntpmrb -V portDesc -c enableTx | grep -qv enableTx=yes'
     )}


### PR DESCRIPTION
Needed to resolve `exec` failures due to `/usr/sbin/lldptool` not being
in the path.

```
Error: Parameter onlyif failed on Exec[set-lldp eth0]: 'lldptool get-lldp -i eth0 -g nb adminStatus | grep -qv adminStatus=rxtx' is not qualified and no path was specified. Please qualify the command or specify a path. at /root/puppet-openlldp/spec/fixtures/modules/openlldp/manifests/config/lldp.pp:73
Wrapped exception:
'lldptool get-lldp -i eth0 -g nb adminStatus | grep -qv adminStatus=rxtx' is not qualified and no path was specified. Please qualify the command or specify a path.
```
