### PR TITLE
Update fact for Facter 3 compatiblity

### DIFF
--- a/lib/facter/openlldp.rb
+++ b/lib/facter/openlldp.rb
@@ -26,8 +26,6 @@
 #   Copyright (C) 2012 Mike Arnold, unless otherwise noted.
 #
 
-require 'facter/util/macaddress'
-
 # http://www.ruby-forum.com/topic/3418285#1040695
 module Enumerable
   def grep_v(cond)
@@ -65,7 +63,7 @@ if File.exists?('/usr/sbin/lldptool')
             when 'chassisID'
               output.split("\n").each do |line|
                 ether = $1 if line.match(/MAC:\s+(.*)/)
-                result = Facter::Util::Macaddress.standardize(ether)
+                result ether.split(":").map{|x| "0#{x}"[-2..-1]}.join(":")
               end
             when 'portID'
               output.split("\n").each do |line|


### PR DESCRIPTION
Prior to this commit, this fact required Facter ruby files that
are no longer vendored in facter 3. This commit traces back the actual
resultant code needed i.e. https://github.com/puppetlabs/facter/blob/20fb9e43b08bc2692311ff05f2767a365ba904ad/lib/facter/util/macaddress.rb#L7 from the last Facter 2.x version that had this code
embdeded in it