### PR TITLE
Correct grep pattern for determining get-lldp status

### DIFF
--- a/manifests/config/lldp.pp
+++ b/manifests/config/lldp.pp
@@ -71,6 +71,6 @@ define openlldp::config::lldp (
     # /bin/grep & /usr/sbin/lldptool
     path    => ['/bin', '/usr/sbin'],
     command => "lldptool set-lldp -i ${interface} ${scope} adminStatus=${adminstatus}",
-    onlyif  => "lldptool get-lldp -i ${interface} ${scope} adminStatus | grep -qv adminStatus=${adminstatus}",
+    onlyif  => "lldptool get-lldp -i ${interface} ${scope} adminStatus | grep -qv adminStatus=${adminstatus}$",
   }
 }

--- a/spec/defines/openlldp_config_lldp_spec.rb
+++ b/spec/defines/openlldp_config_lldp_spec.rb
@@ -27,7 +27,7 @@ describe 'openlldp::config::lldp', :type => 'define' do
     it { should contain_exec('set-lldp myETHERNET').with(
       :path    => ['/bin', '/usr/sbin'],
       :command => 'lldptool set-lldp -i myETHERNET -g nb adminStatus=disabled',
-      :onlyif  => 'lldptool get-lldp -i myETHERNET -g nb adminStatus | grep -qv adminStatus=disabled'
+      :onlyif  => 'lldptool get-lldp -i myETHERNET -g nb adminStatus | grep -qv adminStatus=disabled$'
     )}
   end
 
@@ -37,7 +37,7 @@ describe 'openlldp::config::lldp', :type => 'define' do
     it { should contain_exec('set-lldp myETHERNET').with(
       :path    => ['/bin', '/usr/sbin'],
       :command => 'lldptool set-lldp -i myETHERNET -g nb adminStatus=rx',
-      :onlyif  => 'lldptool get-lldp -i myETHERNET -g nb adminStatus | grep -qv adminStatus=rx'
+      :onlyif  => 'lldptool get-lldp -i myETHERNET -g nb adminStatus | grep -qv adminStatus=rx$'
     )}
   end
 
@@ -47,7 +47,7 @@ describe 'openlldp::config::lldp', :type => 'define' do
     it { should contain_exec('set-lldp myETHERNET').with(
       :path    => ['/bin', '/usr/sbin'],
       :command => 'lldptool set-lldp -i myETHERNET -g nb adminStatus=tx',
-      :onlyif  => 'lldptool get-lldp -i myETHERNET -g nb adminStatus | grep -qv adminStatus=tx'
+      :onlyif  => 'lldptool get-lldp -i myETHERNET -g nb adminStatus | grep -qv adminStatus=tx$'
     )}
   end
 
@@ -57,7 +57,7 @@ describe 'openlldp::config::lldp', :type => 'define' do
     it { should contain_exec('set-lldp myETHERNET').with(
       :path    => ['/bin', '/usr/sbin'],
       :command => 'lldptool set-lldp -i myETHERNET -g nb adminStatus=rxtx',
-      :onlyif  => 'lldptool get-lldp -i myETHERNET -g nb adminStatus | grep -qv adminStatus=rxtx'
+      :onlyif  => 'lldptool get-lldp -i myETHERNET -g nb adminStatus | grep -qv adminStatus=rxtx$'
     )}
   end
 
@@ -85,7 +85,7 @@ describe 'openlldp::config::lldp', :type => 'define' do
     it { should contain_exec('set-lldp myETHERNET').with(
       :path    => ['/bin', '/usr/sbin'],
       :command => 'lldptool set-lldp -i myETHERNET -g ncb adminStatus=rxtx',
-      :onlyif  => 'lldptool get-lldp -i myETHERNET -g ncb adminStatus | grep -qv adminStatus=rxtx'
+      :onlyif  => 'lldptool get-lldp -i myETHERNET -g ncb adminStatus | grep -qv adminStatus=rxtx$'
     )}
   end
 
@@ -99,7 +99,7 @@ describe 'openlldp::config::lldp', :type => 'define' do
     it { should contain_exec('set-lldp myETHERNET').with(
       :path    => ['/bin', '/usr/sbin'],
       :command => 'lldptool set-lldp -i myETHERNET -g nntpmrb adminStatus=rxtx',
-      :onlyif  => 'lldptool get-lldp -i myETHERNET -g nntpmrb adminStatus | grep -qv adminStatus=rxtx'
+      :onlyif  => 'lldptool get-lldp -i myETHERNET -g nntpmrb adminStatus | grep -qv adminStatus=rxtx$'
     )}
   end
 


### PR DESCRIPTION
Anchor the match to end of line to prevent a current status of
"rxtx" from matching against a desired status of "rx".

Resolves #11