### PR TITLE
support for configuring: portID TLV > subtype

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ openlldp::config::tlv { 'eth0':
   sysDesc  => 'yes',
   sysCap   => 'yes',
   mngAddr  => 'yes',
+  portIDsubtype => 'ifname',  #portID TLV can display mac, ip or ifname (interface name).
 }
 ```
 

--- a/manifests/config/tlv.pp
+++ b/manifests/config/tlv.pp
@@ -94,9 +94,9 @@ define openlldp::config::tlv (
   #validate_re($status, $states, '$status parameter must be yes or no.')
   case $portIDsubtype {
     undef: {}
-    /^(mac|MAC|PORT_ID_MAC_ADDRESS)$/: { $portIDsubtype = 'PORT_ID_MAC_ADDRESS' }
-    /^(ip|IP|PORT_ID_NETWORK_ADDRESS)$/: { $portIDsubtype = 'PORT_ID_NETWORK_ADDRESS' }
-    /^(ifname|Ifname|PORT_ID_INTERFACE_NAME)$/: { $portIDsubtype = 'PORT_ID_INTERFACE_NAME' }
+    /^(mac|MAC|PORT_ID_MAC_ADDRESS)$/: { $_portIDsubtype = 'PORT_ID_MAC_ADDRESS' }
+    /^(ip|IP|PORT_ID_NETWORK_ADDRESS)$/: { $_portIDsubtype = 'PORT_ID_NETWORK_ADDRESS' }
+    /^(ifname|Ifname|PORT_ID_INTERFACE_NAME)$/: { $_portIDsubtype = 'PORT_ID_INTERFACE_NAME' }
     default: {
       fail('$portIDsubtype parameter, if set, must be "mac", "ip" or "ifname"')
     }
@@ -143,8 +143,8 @@ define openlldp::config::tlv (
   }
   if $portIDsubtype {
     exec { "set-tlv ${interface} portID: subtype > ${portIDsubtype}" :
-      command => "lldptool set-tlv -i ${interface} ${scope} -V portID -c subtype=${portIDsubtype}",
-      unless  => "test \"$(lldptool get-tlv -i ${interface} ${scope} -V portID -c subtype)\" = \"subtype=${portIDsubtype}\"",
+      command => "lldptool set-tlv -i ${interface} ${scope} -V portID -c subtype=${_portIDsubtype}",
+      unless  => "test \"$(lldptool get-tlv -i ${interface} ${scope} -V portID -c subtype)\" = \"subtype=${_portIDsubtype}\"",
     }
   }
 #  exec { "set-tlv ${interface} status" :

--- a/manifests/config/tlv.pp
+++ b/manifests/config/tlv.pp
@@ -117,8 +117,8 @@ define openlldp::config::tlv (
   }
 
   Exec {
-    # /bin/grep & /usr/sbin/lldptool
-    path => ['/bin', '/usr/sbin']
+    # /bin/grep, /usr/bin/test & /usr/sbin/lldptool
+    path => ['/bin', '/usr/bin', '/usr/sbin']
   }
 
   exec { "set-tlv ${interface} portDesc" :

--- a/manifests/config/tlv.pp
+++ b/manifests/config/tlv.pp
@@ -30,6 +30,15 @@
 #   Whether to transmit the Management Address TLV (Type = 8).
 #   Default: no
 #
+# [*portIDsubtype*]
+#   Set subtype for portID TLV (Type = 2. Mandatory).
+#   This will determine what the portID TLV displays.
+#   Possible values:
+#     mac (or PORT_ID_MAC_ADDRESS)       - mac address
+#     ip  (or PORT_ID_NETWORK_ADDRESS)   - ip address
+#     ifname (or PORT_ID_INTERFACE_NAME) - interface name
+#   Default: undef => OS default (mac)
+#
 # [*bridgescope*]
 #   Specify the bridge scope upon which to operate.
 #   Values: nearest_bridge (nb), nearest_customer_bridge (ncb),
@@ -84,7 +93,7 @@ define openlldp::config::tlv (
   validate_re($mngAddr,  $states, '$mngAddr parameter must be yes or no.')
   #validate_re($status, $states, '$status parameter must be yes or no.')
   case $portIDsubtype {
-    undef:
+    undef: {}
     /^(mac|MAC|PORT_ID_MAC_ADDRESS)$/: { $portIDsubtype = 'PORT_ID_MAC_ADDRESS' }
     /^(ip|IP|PORT_ID_NETWORK_ADDRESS)$/: { $portIDsubtype = 'PORT_ID_NETWORK_ADDRESS' }
     /^(ifname|Ifname|PORT_ID_INTERFACE_NAME)$/: { $portIDsubtype = 'PORT_ID_INTERFACE_NAME' }


### PR DESCRIPTION
..if anyone is interested :)

just exposes portID > subtype setting, which determines what Port ID TLV will display.
eg set subtype=PORT_ID_INTERFACE_NAME, and Port ID will display like:
```
Port ID TLV
        Ifname: eno1
```